### PR TITLE
Migrate to allennlp 2.0

### DIFF
--- a/experiments/generation/model.jsonnet
+++ b/experiments/generation/model.jsonnet
@@ -4,7 +4,6 @@ local bert_model = "facebook/bart-large";
   "dataset_reader": {
     "type": "question_generation",
     "model_name": bert_model,
-    "lazy": false
   },
   "train_data_path": "experiments/generation/data/train.jsonl",
   "validation_data_path": "experiments/generation/data/valid.jsonl",

--- a/qaeval/generation/dataset_reader.py
+++ b/qaeval/generation/dataset_reader.py
@@ -3,7 +3,6 @@ from allennlp.data import DatasetReader, Instance
 from allennlp.data.fields import MetadataField, TextField
 from allennlp.data.token_indexers import PretrainedTransformerIndexer
 from allennlp.data.tokenizers import PretrainedTransformerTokenizer
-from overrides import overrides
 from typing import Any, Dict, Iterable, Optional
 
 from qaeval.generation.util import SPAN_START_TOKEN, SPAN_END_TOKEN
@@ -11,20 +10,21 @@ from qaeval.generation.util import SPAN_START_TOKEN, SPAN_END_TOKEN
 
 @DatasetReader.register('question_generation')
 class QuestionGenerationDatasetReader(DatasetReader):
-    def __init__(self,
-                 model_name: str,
-                 lazy: bool = False):
-        super().__init__(lazy=lazy)
+    def __init__(self, model_name: str, **kwargs):
+        super().__init__(
+            manual_distributed_sharding=True,
+            manual_multiprocess_sharding=True,
+            **kwargs
+        )
         self.tokenizer = PretrainedTransformerTokenizer(model_name)
         self.token_indexers = {'tokens': PretrainedTransformerIndexer(model_name, namespace='tokens')}
 
         # Add the tokens which will mark the answer span
         self.tokenizer.tokenizer.add_tokens([SPAN_START_TOKEN, SPAN_END_TOKEN])
 
-    @overrides
     def _read(self, file_path: str) -> Iterable[Instance]:
         with open(file_path, 'r') as f:
-            for line in f:
+            for line in self.shard_iterable(f):
                 data = json.loads(line)
                 context = data['context']
                 start = data['answer_start']
@@ -36,7 +36,6 @@ class QuestionGenerationDatasetReader(DatasetReader):
     def _insert_span_symbols(self, context: str, start: int, end: int) -> str:
         return f'{context[:start]}{SPAN_START_TOKEN} {context[start:end]} {SPAN_END_TOKEN}{context[end:]}'
 
-    @overrides
     def text_to_instance(self,
                          context: str,
                          start: int,
@@ -53,7 +52,7 @@ class QuestionGenerationDatasetReader(DatasetReader):
         answer = context[start:end]
         marked_context = self._insert_span_symbols(context, start, end)
         source_tokens = self.tokenizer.tokenize(marked_context)
-        fields['source_tokens'] = TextField(source_tokens, self.token_indexers)
+        fields['source_tokens'] = TextField(source_tokens)
         metadata['answer'] = answer
         metadata['answer_start'] = start
         metadata['answer_end'] = end
@@ -63,9 +62,13 @@ class QuestionGenerationDatasetReader(DatasetReader):
 
         if question is not None:
             target_tokens = self.tokenizer.tokenize(question)
-            fields['target_tokens'] = TextField(target_tokens, self.token_indexers)
+            fields['target_tokens'] = TextField(target_tokens)
             metadata['question'] = question
             metadata['target_tokens'] = target_tokens
 
         fields['metadata'] = MetadataField(metadata)
         return Instance(fields)
+
+    def apply_token_indexers(self, instance: Instance) -> None:
+        instance.fields["source_tokens"].token_indexers = self.token_indexers
+        instance.fields["target_tokens"].token_indexers = self.token_indexers

--- a/qaeval/generation/model.py
+++ b/qaeval/generation/model.py
@@ -10,7 +10,6 @@ from allennlp.models import Model
 from allennlp.nn.beam_search import BeamSearch
 from allennlp.nn.util import sequence_cross_entropy_with_logits
 from allennlp.predictors import Predictor
-from overrides import overrides
 from transformers import BartForConditionalGeneration
 from tqdm import tqdm
 from typing import Any, Dict, List, Tuple
@@ -87,7 +86,6 @@ class _QuestionGenerationModel(Model):
             self._end_id, max_steps=max_decoding_steps, beam_size=beam_size or 1
         )
 
-    @overrides
     def forward(self,
                 source_tokens: TextFieldTensors,
                 metadata: List[Dict[str, Any]],
@@ -240,7 +238,6 @@ class _QuestionGenerationModel(Model):
 
         return log_probabilities, state
 
-    @overrides
     def make_output_human_readable(self, output_dict: Dict[str, torch.Tensor]) -> Dict[str, Any]:
         """
         # Parameters

--- a/qaeval/generation/predictor.py
+++ b/qaeval/generation/predictor.py
@@ -2,18 +2,15 @@ import json
 from allennlp.common.util import JsonDict
 from allennlp.data import Instance
 from allennlp.predictors import Predictor
-from overrides import overrides
 
 
 @Predictor.register('question_generation')
 class QuestionGenerationPredictor(Predictor):
-    @overrides
     def _json_to_instance(self, json_dict: JsonDict) -> Instance:
         return self._dataset_reader.text_to_instance(context=json_dict['text'],
                                                      start=json_dict['start'],
                                                      end=json_dict['end'])
 
-    @overrides
     def dump_line(self, outputs: JsonDict) -> str:
         input_dict = outputs['metadata']['input_dict']
         input_dict['question'] = outputs['predicted_question']

--- a/qaeval/scoring/lerc/lerc_dataset_reader.py
+++ b/qaeval/scoring/lerc/lerc_dataset_reader.py
@@ -1,7 +1,6 @@
 import logging
 import json
 import numpy as np
-from overrides import overrides
 from transformers import BertTokenizer
 
 from allennlp.data.dataset_readers.dataset_reader import DatasetReader
@@ -20,15 +19,14 @@ class LERCDatasetReader(DatasetReader):
         max_length: int = 512,
         holdout_sets: list = [],
         augment: bool = True,
-        lazy: bool = False
+        **kwargs,
     ) -> None:
-        super().__init__(lazy)
+        super().__init__(**kwargs)
         self.max_length = max_length
         self.holdout_sets = holdout_sets if type(holdout_sets) == list else [holdout_sets]
         self.augment = augment
         self.tokenizer = BertTokenizer.from_pretrained(bert_model)
 
-    @overrides
     def _read(self, file_path: str):
         lines = []
         mocha_dataset = json.load(open(file_path))
@@ -85,7 +83,6 @@ class LERCDatasetReader(DatasetReader):
         for line in lines:
             yield self.text_to_instance(**line)
 
-    @overrides
     def text_to_instance(
         self, context, question, reference, candidate, score=None
     ) -> Instance:

--- a/qaeval/scoring/lerc/lerc_model.py
+++ b/qaeval/scoring/lerc/lerc_model.py
@@ -1,5 +1,4 @@
 import logging
-from overrides import overrides
 from transformers import BertModel
 import torch
 from typing import Dict
@@ -19,7 +18,6 @@ class LERC(Model):
     def embedding_dim(self):
         return self.bert.embeddings.word_embeddings.embedding_dim
 
-    @overrides
     def get_metrics(self, reset: bool = False) -> Dict[str, float]:
         return {metric_name: metric.get_metric(reset)
                 for metric_name, metric in self.metrics.items()}
@@ -44,7 +42,6 @@ class LERC(Model):
         self.loss = torch.nn.MSELoss()
         initializer(self)
 
-    @overrides
     def forward(
         self,
         input_ids: torch.Tensor,

--- a/qaeval/scoring/lerc/lerc_predictor.py
+++ b/qaeval/scoring/lerc/lerc_predictor.py
@@ -1,5 +1,3 @@
-from overrides import overrides
-
 from allennlp.data import DatasetReader, Instance
 from allennlp.models import Model
 from allennlp.predictors.predictor import Predictor
@@ -14,7 +12,6 @@ class LERCPredictor(Predictor):
     def __init__(self, model: Model, dataset_reader: DatasetReader) -> None:
         super().__init__(model, dataset_reader)
 
-    @overrides
     def _json_to_instance(self, inputs) -> Instance:
         inputs = {
             'context': inputs['context'],

--- a/qaeval/scoring/lerc/pretrain_model.py
+++ b/qaeval/scoring/lerc/pretrain_model.py
@@ -1,5 +1,4 @@
 import logging
-from overrides import overrides
 from typing import Dict
 
 import torch
@@ -18,7 +17,6 @@ class PretrainLERC(Model):
     def embedding_dim(self):
         return self.bert.embeddings.word_embeddings.embedding_dim
 
-    @overrides
     def get_metrics(self, reset: bool = False) -> Dict[str, float]:
         return {metric_name: metric.get_metric(reset)
                 for metric_name, metric in self.metrics.items()}
@@ -36,7 +34,6 @@ class PretrainLERC(Model):
         self.loss = torch.nn.CrossEntropyLoss()
         initializer(self)
 
-    @overrides
     def forward(
         self,
         input_ids: torch.Tensor,

--- a/setup.py
+++ b/setup.py
@@ -15,12 +15,12 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     python_requires='>=3.6',
     install_requires=[
-        'allennlp==1.1.0',
-        'click==7.1.2',
-        'edlib',
-        'spacy==2.2.4',
-        'torch==1.6.0',
-        'transformers==3.0.2',
+        'allennlp>=2.9.0',
+        'click>=7.1.2',
+        'edlib>=1.2.7',
+        'spacy>=2.2.4',
+        'torch>=1.6.0',
+        'transformers>=4.1',
         'urllib3>=1.25.10'
     ]
 )


### PR DESCRIPTION
Makes all the required changes to use QAEval with newer versions of the transformers library (i.e. `>=4.1`). For this, we have to upgrade AllenNLP to at least 2.0. I did this following their [migration guide](https://github.com/allenai/allennlp/discussions/4933), but effectively the only changes are:

1. Remove all calls to the `overrides` package
2. Remove all `lazy` arguments
3. Upgrade the dataset readers following the [migration guide](https://github.com/allenai/allennlp/discussions/4933).

I encountered a few other issues along the way:

- The `config.json`